### PR TITLE
Port theme customizations from testing site

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,34 @@
+{{ partial "default_head.html" . }}
+
+<div class="post">
+  <h1 class="post-title">{{ .Title }}</h1>
+  <span class="post-date">{{ .Site.Params.DateForm | default "Jan 2, 2006" | .Date.Format }} &middot; Filed in <a href="/categories/{{ .Params.Categories | lower }}">{{ .Params.Categories }}</a></span>
+  {{ .Content }}
+
+  <h3>Metadata and Navigation</h3>
+  <span class="post-meta">
+  {{ range .Params.tags }}<i class="fa fa-tag" aria-hidden="true"></i>&#160;<a href="/tags/{{ . | lower }}">{{ . }}</a> {{ end }}
+
+  {{ with .PrevInSection }}
+  <br />
+  <i class="fa fa-arrow-circle-left" aria-hidden="true"></i> Previous Post: <a href="{{ .Permalink }}">{{ .Title }}</a>
+  {{ end }}
+  
+  {{ with .NextInSection }}
+  <br />
+   <i class="fa fa-arrow-circle-right" aria-hidden="true"></i> Next Post: <a href="{{ .Permalink }}">{{ .Title }}</a>
+  {{ end }}
+  </span>
+</div>
+
+<div class="related">
+  <h3>Related Posts</h3>
+  <ul class="related-posts">
+    {{ range first 3 ( where ( where .Site.Pages.ByDate.Reverse ".Params.tags" "intersect" .Params.tags ) "Permalink" "!=" .Permalink ) }}
+      <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+    {{ end }}
+  </ul>
+</div>
+
+
+{{ partial "default_foot.html" . }}

--- a/layouts/indexes/post.html
+++ b/layouts/indexes/post.html
@@ -1,0 +1,12 @@
+{{ partial "default_head.html" . }}
+
+<div class="post">
+  <h1 class="post-title">{{ .Title }}</h1>
+  <ul id="list">
+      {{ range .Data.Pages }}
+        {{ .Render "li" }}
+      {{ end }}
+  </ul>
+</div>
+
+{{ partial "default_foot.html" . }}

--- a/layouts/partials/default_head.html
+++ b/layouts/partials/default_head.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
+
+  {{ partial "head.html" . }}
+
+  <body class="theme-base-0d">
+
+    {{ partial "sidebar.html" . }}
+
+    <!-- Wrap is the content to shift when toggling the sidebar. We wrap the
+         content to avoid any CSS collisions with our real content. -->
+    <div class="wrap">
+      <div class="masthead">
+        <div class="container">
+          <h3 class="masthead-title">
+            <a href="/" title="Home">{{ .Site.Params.Title }}</a>
+            <small>{{ .Site.Params.Tagline }}</small>
+          </h3>
+        </div>
+      </div>
+
+      <div class="container content">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,32 @@
+<head>
+  <link href="http://gmpg.org/xfn/11" rel="profile">
+  <meta http-equiv="content-type" content="text/html; charset=utf-8">
+
+  <!-- Enable responsiveness on mobile devices-->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+
+  <title>
+    {{ if eq .URL "/" }}
+      {{ .Site.Params.Title }} &middot; {{ .Site.Params.Tagline }}
+    {{ else }}
+      {{ .Title }} &middot; {{ .Site.Params.Title }}
+    {{ end }}
+  </title>
+
+  <!--Metadata-->
+  {{ with .Site.Params.Author.Name }}<meta name="author" content="{{ . }}">{{ end }}
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="/css/poole.css">
+  <link rel="stylesheet" href="/css/syntax.css">
+  <link rel="stylesheet" href="/css/lanyon.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400">
+  <link rel="stylesheet" href="/public/font-awesome/css/font-awesome.min.css">
+
+  <!-- Icons -->
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/assets/apple-touch-icon-144-precomposed.png">
+  <link rel="shortcut icon" href="/assets/favicon.ico">
+
+  <!-- RSS -->
+  <link rel="alternate" type="application/rss+xml" title="RSS" href="/atom.xml">
+</head>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,0 +1,40 @@
+<!-- Target for toggling the sidebar `.sidebar-checkbox` is for regular
+     styles, `#sidebar-checkbox` for behavior. -->
+<input type="checkbox" class="sidebar-checkbox" id="sidebar-checkbox">
+
+<!-- Toggleable sidebar -->
+<div class="sidebar" id="sidebar">
+  <div class="sidebar-item">
+    <p><img src="/public/img/orbits-thumb.gif" alt="Orbits" width="128" height="128" /></p>
+    <p>{{ .Site.Params.Description }}</p>
+  </div>
+
+  <nav class="sidebar-nav">
+    <a class="sidebar-nav-item {{ if eq .URL "/" }} active {{ end }}" href="/">Home</a>
+    <a class="sidebar-nav-item {{ if eq .URL "/post/" }} active {{ end }}" href="/post">Posts</a>
+
+    {{ $thisperma := .Permalink }}
+    {{ range .Site.Pages.ByWeight }}
+      {{ if isset .Params "sidebar" }}
+        <a class="sidebar-nav-item {{ if eq .Permalink $thisperma }} active {{ end }}" href="{{ .Permalink }}">{{ .Title }}</a>
+      {{ end }}
+    {{ end }}
+
+    <a class="sidebar-nav-item" href="{{ .Site.Params.Github.Url }}/archive/{{ .Site.Params.Github.Head }}.zip">Download</a>
+    <a class="sidebar-nav-item" href="{{ .Site.Params.Github.Url }}">GitHub project</a>
+    <span class="sidebar-nav-item">Currently on {{ .Site.Params.Github.Head }}</span>
+  </nav>
+
+  <div class="sidebar-item">
+    <p>
+      <a href="https://github.com/{{ .Site.Params.author.github }}"><i class="fa fa-github fa-3x"></i></a>
+      <a href="https://twitter.com/{{ .Site.Params.author.twitter }}"><i class="fa fa-twitter fa-3x"></i></a>
+      <a href="https://www.linkedin.com/in/{{ .Site.Params.author.linkedin }}"><i class="fa fa-linkedin-square fa-3x"></i></a>
+      <a href="http://feeds.scottlowe.org/slowe/content/feed/"><i class="fa fa-rss fa-3x"></i></a>
+    </p>
+  </div>
+
+  <div class="sidebar-item">
+    <p>&copy; {{ .Site.LastChange.Year }}. All rights reserved.</p>
+  </div>
+</div>

--- a/layouts/taxonomy/category.html
+++ b/layouts/taxonomy/category.html
@@ -1,0 +1,12 @@
+{{ partial "default_head.html" . }}
+
+<div class="post">
+  <h1 class="post-title">All Posts in Category &ldquo;{{ .Title }}&rdquo;</h1>
+  <ul id="list">
+    {{ range .Data.Pages }}
+      {{ .Render "li" }}
+    {{ end }}
+  </ul>
+</div>
+
+{{ partial "default_foot.html" . }}

--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -1,0 +1,12 @@
+{{ partial "default_head.html" . }}
+
+<div class="post">
+  <h1 class="post-title">All Posts Tagged &ldquo;{{ .Title }}&rdquo;</h1>
+  <ul id="list">
+    {{ range .Data.Pages }}
+      {{ .Render "li" }}
+    {{ end }}
+  </ul>
+</div>
+
+{{ partial "default_foot.html" . }}


### PR DESCRIPTION
Move theme files modified from vanilla theme from testing to correct location in new repository (in "layouts" so they override "themes/theme-name/layouts" per Hugo lookup order). Modified files determine using a directory/file comparison tool, then manually copying files over to new location.