### PR TITLE
Fix incorrect references to site parameters

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,7 +14,7 @@
   </title>
 
   <!--Metadata-->
-  {{ with .Site.Params.Author.Name }}<meta name="author" content="{{ . }}">{{ end }}
+  {{ with .Site.Params.Author }}<meta name="author" content="{{ . }}">{{ end }}
 
   <!-- CSS -->
   <link rel="stylesheet" href="/css/poole.css">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -27,9 +27,9 @@
 
   <div class="sidebar-item">
     <p>
-      <a href="https://github.com/{{ .Site.Params.author.github }}"><i class="fa fa-github fa-3x"></i></a>
-      <a href="https://twitter.com/{{ .Site.Params.author.twitter }}"><i class="fa fa-twitter fa-3x"></i></a>
-      <a href="https://www.linkedin.com/in/{{ .Site.Params.author.linkedin }}"><i class="fa fa-linkedin-square fa-3x"></i></a>
+      <a href="https://github.com/{{ .Site.Params.GitHubUser }}"><i class="fa fa-github fa-3x"></i></a>
+      <a href="https://twitter.com/{{ .Site.Params.TwitterUser }}"><i class="fa fa-twitter fa-3x"></i></a>
+      <a href="https://www.linkedin.com/in/{{ .Site.Params.LinkedInUser }}"><i class="fa fa-linkedin-square fa-3x"></i></a>
       <a href="http://feeds.scottlowe.org/slowe/content/feed/"><i class="fa fa-rss fa-3x"></i></a>
     </p>
   </div>


### PR DESCRIPTION
As part of configuration update, some site parameters were changed. This commit fixes incorrect references to now-defunct site parameters.