### PR TITLE
Fixed OVS mailing list URLs.

### DIFF
--- a/content/post/2012-11-27-connecting-ovs-bridges-with-patch-ports.md
+++ b/content/post/2012-11-27-connecting-ovs-bridges-with-patch-ports.md
@@ -68,7 +68,7 @@ Let's review this a bit:
 
 With this configuration, I can start up a guest domain attached to `ovsbr2`---which has no physical uplinks---and gain connectivity to the outside world via the patch ports that connect it to `ovsbr0` and its uplinks.
 
-The next natural question (at least, it was the next natural question for me): how many levels of connected OVS bridges can you build? It turns out the answer is 5 (as described [here](http://openvswitch.org/pipermail/discuss/2012-July/007689.html)).
+The next natural question (at least, it was the next natural question for me): how many levels of connected OVS bridges can you build? It turns out the answer is 5 (as described [here](http://openvswitch.org/pipermail/ovs-discuss/2012-July/007689.html)).
 
 OK, this is interesting (sort of), but what sort of uses does this have? Well, I'm still exploring that myself, and I'd love to hear from readers as to how they might see this functionality utilized. Here are two examples of which I know:
 

--- a/content/post/2015-07-14-technology-short-take-52.md
+++ b/content/post/2015-07-14-technology-short-take-52.md
@@ -76,7 +76,7 @@ It's time to wrap up now. I hope that I was able to include something useful for
 
 
 [link-1]: http://blogs.vmware.com/performance/2015/05/running-transactional-workloads-using-docker-containers-vsphere-6-0.html
-[link-2]: http://openvswitch.org/pipermail/dev/2015-March/052663.html
+[link-2]: http://openvswitch.org/pipermail/ovs-dev/2015-March/052663.html
 [link-3]: https://www.sumologic.com/2015/04/16/new-docker-logging-drivers/
 [link-4]: http://www.datacenterknowledge.com/archives/2015/05/22/openstack-magnum-containers-service-cloud-operators/
 [link-5]: https://www.youtube.com/watch?v=kEzXTq2fPDg


### PR DESCRIPTION
Reference command for my future self:

```bash
find . -type f -iname "*.md" -print0 | parallel -0 gsed -i '' "s#//openvswitch.org/pipermail/#//openvswitch.org/pipermail/ovs-#g" {}
```

_Change `gsed` to `sed` on Linux._