### PR TITLE
Add "Related Posts" section

### DIFF
--- a/layouts/partials/default_head.html
+++ b/layouts/partials/default_head.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
 
-  {{ partial "head.html" . }}
+  {{- partial "head.html" . -}}
 
   <body class="theme-base-0d">
 
-    {{ partial "sidebar.html" . }}
+    {{- partial "sidebar.html" . -}}
 
     <!-- Wrap is the content to shift when toggling the sidebar. We wrap the
          content to avoid any CSS collisions with our real content. -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,11 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 
   <title>
-    {{ if eq .URL "/" }}
-      {{ .Site.Params.Title }} - {{ .Site.Params.Tagline }}
+    {{- if eq .URL "/" -}}
+      {{- .Site.Params.Title }} - {{ .Site.Params.Tagline -}}
     {{ else }}
-      {{ .Title }} - {{ .Site.Params.Title }} - {{ .Site.Params.Tagline }}
-    {{ end }}
+      {{- .Title }} - {{ .Site.Params.Title }} - {{ .Site.Params.Tagline -}}
+    {{- end -}}
   </title>
 
   <!--Metadata-->

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,4 +1,4 @@
-{{ partial "default_head.html" . }}
+{{- partial "default_head.html" . -}}
 
 <div class="post">
   <h1 class="post-title">{{ .Title }}</h1>
@@ -9,15 +9,15 @@
   <span class="post-meta">
   {{ range .Params.tags }}<i class="fa fa-tag" aria-hidden="true"></i>&#160;<a href="/tags/{{ . | lower }}">{{ . }}</a> {{ end }}
 
-  {{ with .PrevInSection }}
+  {{ with .PrevInSection -}}
   <br />
   <i class="fa fa-arrow-circle-left" aria-hidden="true"></i> Previous Post: <a href="{{ .Permalink }}">{{ .Title }}</a>
-  {{ end }}
+  {{- end }}
   
-  {{ with .NextInSection }}
+  {{ with .NextInSection -}}
   <br />
    <i class="fa fa-arrow-circle-right" aria-hidden="true"></i> Next Post: <a href="{{ .Permalink }}">{{ .Title }}</a>
-  {{ end }}
+  {{- end }}
   </span>
 
   <span class="post-sharing">
@@ -29,4 +29,16 @@
   </span>
 </div>
 
-{{ partial "default_foot.html" . }}
+{{ $related := .Site.RegularPages.Related . | first 3 -}}
+{{- with $related -}}
+<div class="related">
+  <h3>Related Posts</h3>
+  <ul class="related-posts">
+  {{ range . -}}
+  <li><a href="{{ .RelPermalink }}">{{ .Title }}</a> <span class="post-date-list">{{ .Site.Params.DateForm | default "Jan 2, 2006" | .Date.Format }}</span></li> 
+  {{- end }}
+  </ul>
+</div>
+{{- end }}
+
+{{- partial "default_foot.html" . -}}

--- a/static/css/lanyon.css
+++ b/static/css/lanyon.css
@@ -362,9 +362,9 @@ a.sidebar-nav-item:focus {
 
 /* Related posts */
 .related {
-  border-top: 1px solid #eee;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
+  border-top: none;
+  padding-top: 0;
+  margin-top: -2em;
 }
 .related-posts {
   padding-left: 0;


### PR DESCRIPTION
Restore the "Related Posts" functionality that existed in previous versions of the site (now made faster based on new functionality in Hugo 0.27).