### PR TITLE
Add links for taxonomy RSS feeds

### DIFF
--- a/layouts/taxonomy/category.html
+++ b/layouts/taxonomy/category.html
@@ -2,7 +2,7 @@
 
 <div class="post">
   <h1 class="post-title">All Posts in Category &ldquo;{{ .Title }}&rdquo;</h1>
-  <span class="post-date"><i class="fa fa-arrow-circle-left" aria-hidden="true"></i> Back to <a href="/categories/">Post Categories</a></span>
+  <span class="post-date"><i class="fa fa-arrow-circle-left" aria-hidden="true"></i> Back to <a href="/categories/">Post Categories</a> &middot; <i class="fa fa-rss" aria-hidden="true"></i> <a href="/categories/{{ .Title | lower }}/feed.xml">RSS Feed</a> for this category</span>
   <ul id="list">
     {{ range .Data.Pages }}
       {{ .Render "li" }}

--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -2,7 +2,7 @@
 
 <div class="post">
   <h1 class="post-title">All Posts With Tag &ldquo;{{ .Title }}&rdquo;</h1>
-  <span class="post-date"><i class="fa fa-arrow-circle-left" aria-hidden="true"></i> Back to <a href="/tags/">Content Tags</a></span>
+  <span class="post-date"><i class="fa fa-arrow-circle-left" aria-hidden="true"></i> Back to <a href="/tags/">Content Tags</a> &middot; <i class="fa fa-rss" aria-hidden="true"></i> <a href="/tags/{{ .Title | lower }}/feed.xml">RSS Feed</a> for this tag</span>
   <ul id="list">
     {{ range .Data.Pages }}
       {{ .Render "li" }}


### PR DESCRIPTION
Since Hugo is able to easily generate RSS feeds for specific taxonomy terms, this PR modifies the layout templates to include links to the taxonomy-specific RSS feed URLs.

Closes #13.