### PR TITLE
Update Technology Short Take titles

### DIFF
--- a/content/post/2017-03-24-technology-short-take-80.md
+++ b/content/post/2017-03-24-technology-short-take-80.md
@@ -21,7 +21,7 @@ tags:
 - Photon
 - Linux
 - Vagrant
-title: 'Technology Short Take #80'
+title: 'Technology Short Take 80'
 url: /2017/03/24/technology-short-take-80/
 ---
 

--- a/content/post/2017-04-07-technology-short-take-81.md
+++ b/content/post/2017-04-07-technology-short-take-81.md
@@ -23,7 +23,7 @@ tags:
 - Fusion
 - PowerCLI
 - CLI
-title: 'Technology Short Take #81'
+title: 'Technology Short Take 81'
 url: /2017/04/07/technology-short-take-81/
 ---
 

--- a/content/post/2017-05-05-technology-short-take-82.md
+++ b/content/post/2017-05-05-technology-short-take-82.md
@@ -27,7 +27,7 @@ tags:
 - VMware
 - vSphere
 - Fusion
-title: 'Technology Short Take #82'
+title: 'Technology Short Take 82'
 url: /2017/05/05/technology-short-take-82/
 ---
 

--- a/content/post/2017-05-26-technology-short-take-83.md
+++ b/content/post/2017-05-26-technology-short-take-83.md
@@ -19,7 +19,7 @@ tags:
 - OpenStack
 - Docker
 - Git
-title: 'Technology Short Take #83'
+title: 'Technology Short Take 83'
 url: /2017/05/26/technology-short-take-83/
 ---
 

--- a/content/post/2017-06-19-technology-short-take-84.md
+++ b/content/post/2017-06-19-technology-short-take-84.md
@@ -25,7 +25,7 @@ tags:
 - Microsoft
 - Fedora
 - VirtualBox
-title: 'Technology Short Take #84'
+title: 'Technology Short Take 84'
 url: /2017/06/19/technology-short-take-84/
 ---
 

--- a/content/post/2017-08-11-technology-short-take-85.md
+++ b/content/post/2017-08-11-technology-short-take-85.md
@@ -29,7 +29,7 @@ tags:
 - VirtualBox
 - Macintosh
 - Apple
-title: 'Technology Short Take #85'
+title: 'Technology Short Take 85'
 url: /2017/08/11/technology-short-take-85/
 ---
 

--- a/content/post/2017-08-25-technology-short-take-86.md
+++ b/content/post/2017-08-25-technology-short-take-86.md
@@ -22,7 +22,7 @@ tags:
 - VMware
 - vSphere
 - CLI
-title: 'Technology Short Take #86'
+title: 'Technology Short Take 86'
 url: /2017/08/25/technology-short-take-86/
 ---
 

--- a/content/post/2017-09-22-technology-short-take-87.md
+++ b/content/post/2017-09-22-technology-short-take-87.md
@@ -20,7 +20,7 @@ tags:
 - VPN
 - Ubuntu
 - Encryption
-title: "Technology Short Take #87"
+title: "Technology Short Take 87"
 url: /2017/09/22/technology-short-take-87/
 ---
 


### PR DESCRIPTION
This PR removes the pound sign in the titles for the Technology Short Take articles, back to number 80.
