### PR TITLE
Support for Hugo 0.68.3

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
     "baseurl": "https://blog.scottlowe.org/",
     "rssLimit": 15,
-    "disablePathToLower": true,
+    "disablePathToLower": false,
     "languageCode": "en-us",
     "title": "Scott's Weblog",
     "publishdir": "output",

--- a/layouts/fixed/archives.html
+++ b/layouts/fixed/archives.html
@@ -2,7 +2,9 @@
 
 <div class="post">
   <h1 class="post-title">{{ .Title }}</h1>
-  {{ range (where .Site.Pages "Section" "post").GroupByDate "2006" }}
+  <span class="post-date"><i class="fa fa-arrow-circle-left" aria-hidden="true"></i> Back to <a href="/">Home</a></span>
+  <p>On this page you can browse the entire archive of posts on this site, organized by year.</p>
+  {{ range (where .Site.RegularPages "Type" "in" "post").GroupByDate "2006" }}
   <h2>{{ .Key }}</h2>
     <ul id="list">
       {{ range .Pages }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,7 +2,7 @@
 
 <!--Render full content for 5 most recent posts-->
 <div class="posts">
-  {{ range first 5 (where .Data.Pages "Type" "in" "post") }}
+  {{ range first 5 (where .Site.RegularPages "Type" "in" "post") }}
     <div class="post">
       <h1 class="post-title"><a href="{{ .Permalink }}">{{ .Title }}</a></h1>
       <span class="post-date">{{ .Site.Params.DateForm | default "Jan 2, 2006" | .Date.Format }}</span>
@@ -13,7 +13,7 @@
 <!--Render summaries for next 15 posts-->
   <h1>Recent Posts</h1>
 
-  {{ range first 15 (after 5 (where .Data.Pages "Type" "in" "post")) }}
+  {{ range first 15 (after 5 (where .Site.RegularPages "Type" "in" "post")) }}
     <div class="post">
       <h2 class="post-title"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
       <span class="post-date">{{ .Site.Params.DateForm | default "Jan 2, 2006" | .Date.Format }}</span>
@@ -26,7 +26,7 @@
 
   <div class="post">
     <ul id="list">
-    {{ range first 30 (after 20 (where .Data.Pages "Type" "in" "post")) }}
+    {{ range first 30 (after 20 (where .Site.RegularPages "Type" "in" "post")) }}
       {{ .Render "li2"}}
     {{ end }}
     </ul>

--- a/layouts/index.rss.xml
+++ b/layouts/index.rss.xml
@@ -1,0 +1,23 @@
+{{- $limit := .Site.Config.Services.RSS.Limit -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ .Site.Title }} </title>
+    <link>{{ .Permalink }}</link>
+    <language>en-us</language>
+    <author>{{ .Site.Params.Author }}</author>
+    <rights>(C) {{ .Site.LastChange.Year }}</rights>
+    <updated>{{ .Date }}</updated>
+
+    {{ range (where .Site.RegularPages "Type" "in" "post" | first $limit ) }}
+      <item>
+        <title>{{ .Title }}</title>
+        <link>{{ .Permalink }}</link>
+        <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 MST" }}</pubDate>
+        <author>{{ .Site.Params.Author }}</author>
+        <guid>{{ .Permalink }}</guid>
+        <description>{{ .Content | html }}</description>
+      </item>
+    {{ end }}
+  </channel>
+</rss>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 
   <title>
-    {{- if eq .URL "/" -}}
+    {{- if eq .Permalink "/" -}}
       {{- .Site.Params.Title }} - {{ .Site.Params.Tagline -}}
     {{ else }}
       {{- .Title }} - {{ .Site.Params.Title }} - {{ .Site.Params.Tagline -}}
@@ -16,7 +16,7 @@
   <!--Metadata-->
   {{ with .Site.Params.Author }}<meta name="author" content="{{ . }}">{{ end }}
   {{ with .Site.Title }}<meta property="og:site_name" content="{{ . }}">{{ end }}
-  {{ if eq .URL "/" }}
+  {{ if eq .Permalink "/" }}
   <meta property="og:description" content="{{ .Site.Params.Title }} - {{ .Site.Params.Tagline }}">
   <meta property="og:title" content="{{ .Site.Params.Title }} - {{ .Site.Params.Tagline }}">
   {{ else }}
@@ -41,8 +41,8 @@
   <link rel="shortcut icon" href="/assets/favicon.ico">
 
   <!-- RSS -->
-  {{ if .RSSLink -}}
-  <link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" href="{{ .RSSLink }}">
-  <link rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" href="{{ .RSSLink }}">
-  {{- end }}
+  {{ with .OutputFormats.Get "rss" -}}
+    {{ printf `<link rel="alternate" type="%s" href="%s" title="%s" />` .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+    {{ printf `<link rel="feed" type="%s" href="%s" title="%s" />` .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+  {{ end -}}
 </head>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -10,7 +10,7 @@
   </div>
 
   <nav class="sidebar-nav">
-    <a class="sidebar-nav-item {{ if eq .URL "/" }} active {{ end }}" href="/">Home</a>
+    <a class="sidebar-nav-item {{ if eq .Permalink "/" }} active {{ end }}" href="/">Home</a>
     <a class="sidebar-nav-item" href="/about/">About</a>
     <a class="sidebar-nav-item" href="/archives/">Site Archives</a>
     <a class="sidebar-nav-item" href="/categories/">Post Categories</a>

--- a/layouts/taxonomy/tag.terms.html
+++ b/layouts/taxonomy/tag.terms.html
@@ -6,7 +6,7 @@
   <p>Click any of the tags listed below to see a list of all the posts associated with that tag.</p>
   <ul id="list">
       {{ range $name, $taxonomy := .Site.Taxonomies.tags }}
-      <li><a href="/tags/{{ $name | urlize }}">{{ $name | title }}</a></li>
+      <li><a href="/tags/{{ $name | urlize }}">{{ $name }}</a></li>
       {{ end }}
   </ul>
 </div>


### PR DESCRIPTION
This PR updates the site to support Hugo 0.68.3, which had a number of changes from the old version of Hugo that was previously used to generate the site's content.